### PR TITLE
Add Gear class

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,3 +1,10 @@
 class Enigma
 
+  def no_crypt(secret_message, key, date)
+    { encryption: secret_message,
+      key: key,
+      date: date
+    }
+  end
+
 end

--- a/lib/gear.rb
+++ b/lib/gear.rb
@@ -1,0 +1,10 @@
+class Gear
+
+  def make_keys(seed)
+    { A: seed[0..1],
+      B: seed[1..2],
+      C: seed[2..3],
+      D: seed[3..4] }
+  end
+
+end

--- a/lib/gear.rb
+++ b/lib/gear.rb
@@ -12,7 +12,9 @@ class Gear
     new_gear = self.new(cogs[0], cogs[1]) unless cogs.size == 1
     new_gear = self.new(cogs[0]) if cogs.size == 1
     new_gear = self.new if cogs.empty?
-    new_gear.make_shifts
+    { shifts: new_gear.make_shifts,
+      key: new_gear.keys,
+      date: new_gear.date }
   end
 
   def make_keys

--- a/lib/gear.rb
+++ b/lib/gear.rb
@@ -1,22 +1,22 @@
 require "date"
 
 class Gear
-  attr_reader :teeth
+  attr_reader :keys, :date
 
-  def initialize(teeth)
-    @teeth = teeth
+  def initialize(keys=make_random_keys, date=get_date_of_today)
+    @keys = keys
+    @date = date
   end
 
   def make_keys
-    { A: @teeth[0..1].to_i,
-      B: @teeth[1..2].to_i,
-      C: @teeth[2..3].to_i,
-      D: @teeth[3..4].to_i }
+    { A: @keys[0..1].to_i,
+      B: @keys[1..2].to_i,
+      C: @keys[2..3].to_i,
+      D: @keys[3..4].to_i }
   end
 
   def get_date_of_today
-    date = Date.today
-    date.strftime('%d%m%y')
+    Date.today.strftime('%d%m%y')
   end
 
   def make_offsets
@@ -28,7 +28,7 @@ class Gear
   end
 
   def square_date
-    get_date_of_today.to_i**2
+    @date.to_i**2
   end
 
   def make_shifts
@@ -36,6 +36,10 @@ class Gear
       shifts[key] = value + make_offsets[key]
       shifts
     end
+  end
+
+  def make_random_keys
+    rand(1...100_000).to_s.rjust(5, "0")
   end
 
 end

--- a/lib/gear.rb
+++ b/lib/gear.rb
@@ -1,10 +1,29 @@
+require "date"
+
 class Gear
 
   def make_keys(seed)
-    { A: seed[0..1],
-      B: seed[1..2],
-      C: seed[2..3],
-      D: seed[3..4] }
+    { A: seed[0..1].to_i,
+      B: seed[1..2].to_i,
+      C: seed[2..3].to_i,
+      D: seed[3..4].to_i }
+  end
+
+  def get_date_of_today
+    date = Date.today
+    date.strftime('%d%m%y')
+  end
+
+  def make_offsets
+    offsets = square_date.to_s[-4..-1].split("")
+    { A: offsets[0].to_i,
+      B: offsets[1].to_i,
+      C: offsets[2].to_i,
+      D: offsets[3].to_i }
+  end
+
+  def square_date
+    get_date_of_today.to_i**2
   end
 
 end

--- a/lib/gear.rb
+++ b/lib/gear.rb
@@ -1,12 +1,17 @@
 require "date"
 
 class Gear
+  attr_reader :teeth
 
-  def make_keys(seed)
-    { A: seed[0..1].to_i,
-      B: seed[1..2].to_i,
-      C: seed[2..3].to_i,
-      D: seed[3..4].to_i }
+  def initialize(teeth)
+    @teeth = teeth
+  end
+
+  def make_keys
+    { A: @teeth[0..1].to_i,
+      B: @teeth[1..2].to_i,
+      C: @teeth[2..3].to_i,
+      D: @teeth[3..4].to_i }
   end
 
   def get_date_of_today
@@ -24,6 +29,13 @@ class Gear
 
   def square_date
     get_date_of_today.to_i**2
+  end
+
+  def make_shifts
+    make_keys.reduce({}) do |shifts, (key, value)|
+      shifts[key] = value + make_offsets[key]
+      shifts
+    end
   end
 
 end

--- a/lib/gear.rb
+++ b/lib/gear.rb
@@ -8,6 +8,13 @@ class Gear
     @date = date
   end
 
+  def self.shifts(*cogs)
+    new_gear = self.new(cogs[0], cogs[1]) unless cogs.size == 1
+    new_gear = self.new(cogs[0]) if cogs.size == 1
+    new_gear = self.new if cogs.empty?
+    new_gear.make_shifts
+  end
+
   def make_keys
     { A: @keys[0..1].to_i,
       B: @keys[1..2].to_i,
@@ -39,7 +46,7 @@ class Gear
   end
 
   def make_random_keys
-    rand(1...100_000).to_s.rjust(5, "0")
+    rand(0...100_000).to_s.rjust(5, "0")
   end
 
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -1,5 +1,5 @@
 require "./test/test_helper"
-require "./lib/Enigma"
+require "./lib/enigma"
 
 class EnigmaTest < MiniTest::Test
 

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "minitest/pride"
+require "./test/test_helper"
 require "./lib/Enigma"
 
 class EnigmaTest < MiniTest::Test

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -12,4 +12,11 @@ class EnigmaTest < MiniTest::Test
 		assert_instance_of Enigma, @enigma
 	end
 
+  def test_it_can_pass_a_message_given_a_key_and_date
+    # use {encryption: "hello world"} for first tests
+    # change later to {encryption: "keder ohulw"}
+    expected_encryption = { encryption: "hello world", key: "02715", date: "040895" }
+    assert_equal expected_encryption, @enigma.no_crypt("hello world", "02715", "040895")
+  end
+
 end

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -11,4 +11,9 @@ class GearTest < MiniTest::Test
 		assert_instance_of Gear, @gear
 	end
 
+  def test_it_can_make_keys_from_a_seed
+    expected_keys = { A:"02", B:"27", C:"71", D:"15" }
+    assert_equal expected_keys, @gear.make_keys("02715")
+  end
+
 end

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -36,7 +36,7 @@ class GearTest < MiniTest::Test
     @gear.stubs(:get_date_of_today).returns(expected_date)
 
     expected_offset = { A:1, B:0, C:2, D:5 }
-    assert_equal expected_offset, @gear.make_offset
+    assert_equal expected_offset, @gear.make_offsets
   end
 
   def test_it_can_square_the_date

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -1,0 +1,14 @@
+require "./test/test_helper"
+require "./lib/gear"
+
+class GearTest < MiniTest::Test
+
+	def setup
+		@gear = Gear.new
+	end
+
+	def test_it_exists
+		assert_instance_of Gear, @gear
+	end
+
+end

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -10,7 +10,7 @@ class GearTest < MiniTest::Test
 
 	def test_it_exists_with_attributes
 		assert_instance_of Gear, @gear
-    assert_equal "02715", gear.teeth
+    assert_equal "02715", @gear.teeth
 	end
 
   def test_it_can_make_keys
@@ -52,7 +52,9 @@ class GearTest < MiniTest::Test
   end
 
   def test_it_can_make_shifts
-    skip
+    expected_date = "040895"
+    @gear.stubs(:get_date_of_today).returns(expected_date)
+    
     expected_shifts = { A:3, B:27, C:73, D:20 }
     assert_equal expected_shifts, @gear.make_shifts
   end

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -11,6 +11,12 @@ class GearTest < MiniTest::Test
     assert_instance_of Gear, @gear
     assert_equal "02715", @gear.keys
     assert_equal "040895", @gear.date
+
+    gear_1 = Gear.new("02715")
+    assert_instance_of Gear, gear_1
+    assert_equal "02715", gear_1.keys
+    assert_instance_of String, gear_1.date
+    assert_equal 6, gear_1.date.size
   end
 
   def test_it_can_make_keys
@@ -51,8 +57,18 @@ class GearTest < MiniTest::Test
     assert_equal expected_shifts, Gear.shifts("02715", "040895")
   end
 
+  def test_its_class_can_get_shifts_with_one_argument
+    random_shifts = Gear.shifts("040895")
+
+    assert_instance_of Hash, random_shifts
+    assert_equal 4, random_shifts.size
+    assert_equal true, random_shifts.values.all? { |value| value.is_a? Integer }
+    assert_equal true, random_shifts.values.all? { |value| (1...100).include?(value) }
+  end
+
   def test_its_class_can_get_shifts_without_arguments
     random_shifts = Gear.shifts
+
     assert_instance_of Hash, random_shifts
     assert_equal 4, random_shifts.size
     assert_equal true, random_shifts.values.all? { |value| value.is_a? Integer }

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -1,4 +1,5 @@
 require "./test/test_helper"
+require "mocha/minitest"
 require "./lib/gear"
 
 class GearTest < MiniTest::Test
@@ -12,8 +13,24 @@ class GearTest < MiniTest::Test
 	end
 
   def test_it_can_make_keys_from_a_seed
-    expected_keys = { A:"02", B:"27", C:"71", D:"15" }
+    expected_keys = { A:2, B:27, C:71, D:15 }
     assert_equal expected_keys, @gear.make_keys("02715")
+
+    expected_keys = { A:47, B:79, C:91, D:11 }
+    assert_equal expected_keys, @gear.make_keys("47911")
+  end
+
+  def test_it_can_get_the_date
+    expected_date = Date.today.strftime('%d%m%y') #ddmmyy
+    assert_equal expected_date, @gear.get_date_of_today
+  end
+
+  def test_it_can_make_an_offset
+    expected_date = "040895"
+    @gear.stubs(:get_date_of_today).returns(expected_date)
+
+    expected_offset = { A:1, B:0, C:2, D:5 }
+    assert_equal expected_offset, @gear.make_offset
   end
 
 end

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -7,6 +7,11 @@ class GearTest < MiniTest::Test
     @gear = Gear.new("02715", "040895")
   end
 
+  def test_its_class_can_get_shifts
+    expected_shifts = { A:3, B:27, C:73, D:20 }
+    assert_equal expected_shifts, Gear.shifts("02715", "040895")
+  end
+
   def test_it_exists_with_attributes
     assert_instance_of Gear, @gear
     assert_equal "02715", @gear.keys

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -56,26 +56,24 @@ class GearTest < MiniTest::Test
     expected_shifts = { A:3, B:27, C:73, D:20 }
     expected_output = {shifts: expected_shifts, key: "02715", date: "040895"}
     assert_equal expected_output, Gear.shifts("02715", "040895")
-  end
 
-  def test_its_class_can_get_shifts_with_one_argument
-    skip
-    random_shifts = Gear.shifts("040895")
+    shifts_output_1 = Gear.shifts("02715")
+    assert_instance_of Hash, shifts_output_1
+    assert_instance_of Hash, shifts_output_1[:shifts]
+    assert_equal true, shifts_output_1[:shifts].values.all? { |value| value.is_a? Integer }
+    assert_instance_of String, shifts_output_1[:key]
+    assert_equal 5, shifts_output_1[:key].size
+    assert_instance_of String, shifts_output_1[:date]
+    assert_equal 6, shifts_output_1[:date].size
 
-    assert_instance_of Hash, random_shifts
-    assert_equal 4, random_shifts.size
-    assert_equal true, random_shifts.values.all? { |value| value.is_a? Integer }
-    assert_equal true, random_shifts.values.all? { |value| (0...100).include?(value) }
-  end
-
-  def test_its_class_can_get_shifts_without_arguments
-    skip
-    random_shifts = Gear.shifts
-
-    assert_instance_of Hash, random_shifts
-    assert_equal 4, random_shifts.size
-    assert_equal true, random_shifts.values.all? { |value| value.is_a? Integer }
-    assert_equal true, random_shifts.values.all? { |value| (0...100).include?(value) }
+    shifts_output_2 = Gear.shifts
+    assert_instance_of Hash, shifts_output_2
+    assert_instance_of Hash, shifts_output_2[:shifts]
+    assert_equal true, shifts_output_2[:shifts].values.all? { |value| value.is_a? Integer }
+    assert_instance_of String, shifts_output_2[:key]
+    assert_equal 5, shifts_output_2[:key].size
+    assert_instance_of String, shifts_output_2[:date]
+    assert_equal 6, shifts_output_2[:date].size
   end
 
   def test_it_can_exist_and_work_without_arguments

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -89,6 +89,7 @@ class GearTest < MiniTest::Test
     shift_d = key_d + off_d
 
     expected_shifts = { A: shift_a, B: shift_b, C: shift_c, D: shift_d}
+    assert_equal expected_shifts, gear.make_shifts
   end
 
 end

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -44,7 +44,7 @@ class GearTest < MiniTest::Test
     random_keys = @gear.make_random_keys
     assert_instance_of String, random_keys
     assert_equal 5, random_keys.length
-    assert_includes 1...100_000, random_keys.to_i
+    assert_includes 0...100_000, random_keys.to_i
   end
 
   def test_it_can_get_date_of_today
@@ -63,7 +63,7 @@ class GearTest < MiniTest::Test
     assert_instance_of Hash, random_shifts
     assert_equal 4, random_shifts.size
     assert_equal true, random_shifts.values.all? { |value| value.is_a? Integer }
-    assert_equal true, random_shifts.values.all? { |value| (1...100).include?(value) }
+    assert_equal true, random_shifts.values.all? { |value| (0...100).include?(value) }
   end
 
   def test_its_class_can_get_shifts_without_arguments
@@ -72,7 +72,7 @@ class GearTest < MiniTest::Test
     assert_instance_of Hash, random_shifts
     assert_equal 4, random_shifts.size
     assert_equal true, random_shifts.values.all? { |value| value.is_a? Integer }
-    assert_equal true, random_shifts.values.all? { |value| (1...100).include?(value) }
+    assert_equal true, random_shifts.values.all? { |value| (0...100).include?(value) }
   end
 
   def test_it_can_exist_and_work_without_arguments
@@ -81,7 +81,7 @@ class GearTest < MiniTest::Test
     random_keys = gear.keys
     assert_instance_of String, random_keys
     assert_equal 5, random_keys.length
-    assert_includes 1...100_000, random_keys.to_i
+    assert_includes 0...100_000, random_keys.to_i
 
     key_a = random_keys[0..1].to_i
     key_b = random_keys[1..2].to_i

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -53,10 +53,10 @@ class GearTest < MiniTest::Test
 
   def test_its_class_can_get_shifts_without_arguments
     random_shifts = Gear.shifts
-    assert_instance_of Array, random_shifts
+    assert_instance_of Hash, random_shifts
     assert_equal 4, random_shifts.size
     assert_equal true, random_shifts.values.all? { |value| value.is_a? Integer }
-    assert_equal true, random_shifts.values.all? { |value| 1...100.include?(value) }
+    assert_equal true, random_shifts.values.all? { |value| (1...100).include?(value) }
   end
 
   def test_it_can_exist_and_work_without_arguments

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -54,9 +54,21 @@ class GearTest < MiniTest::Test
   def test_it_can_make_shifts
     expected_date = "040895"
     @gear.stubs(:get_date_of_today).returns(expected_date)
-    
+
     expected_shifts = { A:3, B:27, C:73, D:20 }
     assert_equal expected_shifts, @gear.make_shifts
+  end
+
+  def test_it_can_make_random_teeth
+    random_teeth = @gear.make_random_teeth
+
+    assert_instance_of String, random_teeth
+
+    assert_equal 6, random_teeth.length
+    assert_includes 1...100_000, random_teeth.to_i
+
+    expected_keys = { A: random_teeth[0..1], B: random_teeth[1..2], C: random_teeth[2..3], D: random_teeth[3..4] }
+    assert_equal expected_keys, @gear.make_keys
   end
 
 end

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -26,25 +26,30 @@ class GearTest < MiniTest::Test
     assert_equal expected_keys, @gear.make_keys("99999")
   end
 
-  def test_it_can_get_the_date
+  def test_it_can_get_date_of_today
     expected_date = Date.today.strftime('%d%m%y') #ddmmyy
     assert_equal expected_date, @gear.get_date_of_today
   end
 
-  def test_it_can_make_an_offset
+  def test_it_can_make_offsets
     expected_date = "040895"
     @gear.stubs(:get_date_of_today).returns(expected_date)
 
-    expected_offset = { A:1, B:0, C:2, D:5 }
-    assert_equal expected_offset, @gear.make_offsets
+    expected_offsets = { A:1, B:0, C:2, D:5 }
+    assert_equal expected_offsets, @gear.make_offsets
   end
 
-  def test_it_can_square_the_date
+  def test_it_can_square_date
     expected_date = "040895"
     @gear.stubs(:get_date_of_today).returns(expected_date)
 
     expected_square = 1672401025
     assert_equal expected_square, @gear.square_date
+  end
+
+  def test_it_can_make_shifts
+    expected_shifts = { A:3, B:27, C:73, D:20 }
+    assert_equal expected_shifts, @gear.make_shifts
   end
 
 end

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -7,11 +7,6 @@ class GearTest < MiniTest::Test
     @gear = Gear.new("02715", "040895")
   end
 
-  def test_its_class_can_get_shifts
-    expected_shifts = { A:3, B:27, C:73, D:20 }
-    assert_equal expected_shifts, Gear.shifts("02715", "040895")
-  end
-
   def test_it_exists_with_attributes
     assert_instance_of Gear, @gear
     assert_equal "02715", @gear.keys
@@ -49,6 +44,19 @@ class GearTest < MiniTest::Test
   def test_it_can_get_date_of_today
     expected_date = Date.today.strftime('%d%m%y') #ddmmyy
     assert_equal expected_date, @gear.get_date_of_today
+  end
+
+  def test_its_class_can_get_shifts
+    expected_shifts = { A:3, B:27, C:73, D:20 }
+    assert_equal expected_shifts, Gear.shifts("02715", "040895")
+  end
+
+  def test_its_class_can_get_shifts_without_arguments
+    random_shifts = Gear.shifts
+    assert_instance_of Array, random_shifts
+    assert_equal 4, random_shifts.size
+    assert_equal true, random_shifts.values.all? { |value| value.is_a? Integer }
+    assert_equal true, random_shifts.values.all? { |value| 1...100.include?(value) }
   end
 
   def test_it_can_exist_and_work_without_arguments

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -52,12 +52,14 @@ class GearTest < MiniTest::Test
     assert_equal expected_date, @gear.get_date_of_today
   end
 
-  def test_its_class_can_get_shifts
+  def test_its_class_can_output_shifts_key_and_date
     expected_shifts = { A:3, B:27, C:73, D:20 }
-    assert_equal expected_shifts, Gear.shifts("02715", "040895")
+    expected_output = {shifts: expected_shifts, key: "02715", date: "040895"}
+    assert_equal expected_output, Gear.shifts("02715", "040895")
   end
 
   def test_its_class_can_get_shifts_with_one_argument
+    skip
     random_shifts = Gear.shifts("040895")
 
     assert_instance_of Hash, random_shifts
@@ -67,6 +69,7 @@ class GearTest < MiniTest::Test
   end
 
   def test_its_class_can_get_shifts_without_arguments
+    skip
     random_shifts = Gear.shifts
 
     assert_instance_of Hash, random_shifts

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -5,12 +5,13 @@ require "./lib/gear"
 class GearTest < MiniTest::Test
 
 	def setup
-		@gear = Gear.new("02715")
+		@gear = Gear.new("02715", "040895")
 	end
 
 	def test_it_exists_with_attributes
 		assert_instance_of Gear, @gear
     assert_equal "02715", @gear.teeth
+    assert_equal "040895", @gear.date
 	end
 
   def test_it_can_make_keys
@@ -66,9 +67,16 @@ class GearTest < MiniTest::Test
 
     assert_equal 6, random_teeth.length
     assert_includes 1...100_000, random_teeth.to_i
+    #
+    # expected_keys = { A: random_teeth[0..1], B: random_teeth[1..2], C: random_teeth[2..3], D: random_teeth[3..4] }
+    # assert_equal expected_keys, @gear.make_keys
+  end
 
-    expected_keys = { A: random_teeth[0..1], B: random_teeth[1..2], C: random_teeth[2..3], D: random_teeth[3..4] }
-    assert_equal expected_keys, @gear.make_keys
+  def test_it_can_make_keys_from_random_teeth
+    gear = Gear.new
+    assert_instance_of String, gear.teeth
+    assert_equal 6, gear.teeth.length
+    assert_includes 1...100_000, gear.teeth.to_i
   end
 
 end

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -1,34 +1,44 @@
 require "./test/test_helper"
-require "mocha/minitest"
 require "./lib/gear"
 
 class GearTest < MiniTest::Test
 
-	def setup
-		@gear = Gear.new("02715", "040895")
-	end
+  def setup
+    @gear = Gear.new("02715", "040895")
+  end
 
-	def test_it_exists_with_attributes
-		assert_instance_of Gear, @gear
-    assert_equal "02715", @gear.teeth
+  def test_it_exists_with_attributes
+    assert_instance_of Gear, @gear
+    assert_equal "02715", @gear.keys
     assert_equal "040895", @gear.date
-	end
+  end
 
   def test_it_can_make_keys
     expected_keys = { A:2, B:27, C:71, D:15 }
     assert_equal expected_keys, @gear.make_keys
+  end
 
-    gear_1 = Gear.new("47911")
-    expected_keys = { A:47, B:79, C:91, D:11 }
-    assert_equal expected_keys, gear_1.make_keys
+  def test_it_can_make_offsets
+    expected_offsets = { A:1, B:0, C:2, D:5 }
+    assert_equal expected_offsets, @gear.make_offsets
+  end
 
-    gear_2 = Gear.new("00000")
-    expected_keys = { A:00, B:00, C:00, D:00 }
-    assert_equal expected_keys, gear_2.make_keys
+  def test_it_can_square_date
+    expected_square = 1672401025
+    assert_equal expected_square, @gear.square_date
+    assert_equal expected_square, @gear.date.to_i**2
+  end
 
-    gear_3 = Gear.new("99999")
-    expected_keys = { A:99, B:99, C:99, D:99 }
-    assert_equal expected_keys, gear_3.make_keys
+  def test_it_can_make_shifts
+    expected_shifts = { A:3, B:27, C:73, D:20 }
+    assert_equal expected_shifts, @gear.make_shifts
+  end
+
+  def test_it_can_make_random_keys
+    random_keys = @gear.make_random_keys
+    assert_instance_of String, random_keys
+    assert_equal 5, random_keys.length
+    assert_includes 1...100_000, random_keys.to_i
   end
 
   def test_it_can_get_date_of_today
@@ -36,47 +46,44 @@ class GearTest < MiniTest::Test
     assert_equal expected_date, @gear.get_date_of_today
   end
 
-  def test_it_can_make_offsets
-    expected_date = "040895"
-    @gear.stubs(:get_date_of_today).returns(expected_date)
-
-    expected_offsets = { A:1, B:0, C:2, D:5 }
-    assert_equal expected_offsets, @gear.make_offsets
-  end
-
-  def test_it_can_square_date
-    expected_date = "040895"
-    @gear.stubs(:get_date_of_today).returns(expected_date)
-
-    expected_square = 1672401025
-    assert_equal expected_square, @gear.square_date
-  end
-
-  def test_it_can_make_shifts
-    expected_date = "040895"
-    @gear.stubs(:get_date_of_today).returns(expected_date)
-
-    expected_shifts = { A:3, B:27, C:73, D:20 }
-    assert_equal expected_shifts, @gear.make_shifts
-  end
-
-  def test_it_can_make_random_teeth
-    random_teeth = @gear.make_random_teeth
-
-    assert_instance_of String, random_teeth
-
-    assert_equal 6, random_teeth.length
-    assert_includes 1...100_000, random_teeth.to_i
-    #
-    # expected_keys = { A: random_teeth[0..1], B: random_teeth[1..2], C: random_teeth[2..3], D: random_teeth[3..4] }
-    # assert_equal expected_keys, @gear.make_keys
-  end
-
-  def test_it_can_make_keys_from_random_teeth
+  def test_it_can_exist_and_work_without_arguments
     gear = Gear.new
-    assert_instance_of String, gear.teeth
-    assert_equal 6, gear.teeth.length
-    assert_includes 1...100_000, gear.teeth.to_i
+
+    random_keys = gear.keys
+    assert_instance_of String, random_keys
+    assert_equal 5, random_keys.length
+    assert_includes 1...100_000, random_keys.to_i
+
+    key_a = random_keys[0..1].to_i
+    key_b = random_keys[1..2].to_i
+    key_c = random_keys[2..3].to_i
+    key_d = random_keys[3..4].to_i
+
+    expected_keys = { A: key_a, B: key_b, C: key_c, D: key_d }
+    assert_equal expected_keys, gear.make_keys
+
+    date_of_today = gear.date
+    assert_instance_of String, date_of_today
+    assert_equal 6, date_of_today.length
+    assert_includes 1..31, date_of_today[0..1].to_i
+    assert_includes 1..12, date_of_today[2..3].to_i
+    assert_includes 0..99, date_of_today[4..5].to_i
+
+    expected_offsets = gear.square_date.to_s[-4..-1].split("")
+    off_a = expected_offsets[0].to_i
+    off_b = expected_offsets[1].to_i
+    off_c = expected_offsets[2].to_i
+    off_d = expected_offsets[3].to_i
+
+    expected_offsets = { A: off_a, B: off_b, C: off_c, D: off_d }
+    assert_equal expected_offsets, gear.make_offsets
+
+    shift_a = key_a + off_a
+    shift_b = key_b + off_b
+    shift_c = key_c + off_c
+    shift_d = key_d + off_d
+
+    expected_shifts = { A: shift_a, B: shift_b, C: shift_c, D: shift_d}
   end
 
 end

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -18,6 +18,12 @@ class GearTest < MiniTest::Test
 
     expected_keys = { A:47, B:79, C:91, D:11 }
     assert_equal expected_keys, @gear.make_keys("47911")
+
+    expected_keys = { A:00, B:00, C:00, D:00 }
+    assert_equal expected_keys, @gear.make_keys("00000")
+
+    expected_keys = { A:99, B:99, C:99, D:99 }
+    assert_equal expected_keys, @gear.make_keys("99999")
   end
 
   def test_it_can_get_the_date
@@ -31,6 +37,14 @@ class GearTest < MiniTest::Test
 
     expected_offset = { A:1, B:0, C:2, D:5 }
     assert_equal expected_offset, @gear.make_offset
+  end
+
+  def test_it_can_square_the_date
+    expected_date = "040895"
+    @gear.stubs(:get_date_of_today).returns(expected_date)
+
+    expected_square = 1672401025
+    assert_equal expected_square, @gear.square_date
   end
 
 end

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -5,25 +5,29 @@ require "./lib/gear"
 class GearTest < MiniTest::Test
 
 	def setup
-		@gear = Gear.new
+		@gear = Gear.new("02715")
 	end
 
-	def test_it_exists
+	def test_it_exists_with_attributes
 		assert_instance_of Gear, @gear
+    assert_equal "02715", gear.teeth
 	end
 
-  def test_it_can_make_keys_from_a_seed
+  def test_it_can_make_keys
     expected_keys = { A:2, B:27, C:71, D:15 }
-    assert_equal expected_keys, @gear.make_keys("02715")
+    assert_equal expected_keys, @gear.make_keys
 
+    gear_1 = Gear.new("47911")
     expected_keys = { A:47, B:79, C:91, D:11 }
-    assert_equal expected_keys, @gear.make_keys("47911")
+    assert_equal expected_keys, gear_1.make_keys
 
+    gear_2 = Gear.new("00000")
     expected_keys = { A:00, B:00, C:00, D:00 }
-    assert_equal expected_keys, @gear.make_keys("00000")
+    assert_equal expected_keys, gear_2.make_keys
 
+    gear_3 = Gear.new("99999")
     expected_keys = { A:99, B:99, C:99, D:99 }
-    assert_equal expected_keys, @gear.make_keys("99999")
+    assert_equal expected_keys, gear_3.make_keys
   end
 
   def test_it_can_get_date_of_today
@@ -48,6 +52,7 @@ class GearTest < MiniTest::Test
   end
 
   def test_it_can_make_shifts
+    skip
     expected_shifts = { A:3, B:27, C:73, D:20 }
     assert_equal expected_shifts, @gear.make_shifts
   end


### PR DESCRIPTION
The Gear class is intended to be the first object that interacts with the Enigma class.

It take the same arguments as Enigma does (given that the Enigma class validates its own input *** not yet implemented)

And then it returns a hash with three key-value pairs. 

Two are given to Engima for output.

The other one represents a cipher key that will be passed to another class (not yet implemented)

The cipher is a hash with four key-value pairs. The other class (Shifter?) will have to know how to deal with that information.