### PR TITLE
Enigma#encrypt can now output encrypted messages given only an initial message

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -45,9 +45,14 @@ class Enigma
     puts "Invalid input! Execution halted."; exit
   end
 
+  def make_random_keys
+    rand(0...100_000).to_s.rjust(5, "0")
+  end
+
   def encrypt(secret_message, *settings)
     initial_key, offset_key = settings
     reprimand unless is_valid_input?(secret_message, initial_key, offset_key)
+    initial_key ||= make_random_keys
     offset_key ||= get_date_of_today
 
     tokens = Tokenizer.get_tokens(secret_message)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,3 +1,4 @@
+require "date"
 require "./lib/gear"
 require "./lib/tokenizer"
 require "./lib/encrypter"

--- a/lib/gear.rb
+++ b/lib/gear.rb
@@ -1,5 +1,3 @@
-require "date"
-
 class Gear
   attr_reader :keys, :date
 

--- a/lib/gear.rb
+++ b/lib/gear.rb
@@ -1,7 +1,7 @@
 class Gear
   attr_reader :keys, :date
 
-  def initialize(keys=make_random_keys, date)
+  def initialize(keys, date)
     @keys = keys
     @date = date
   end
@@ -35,10 +35,6 @@ class Gear
       shifts[key] = value + make_offsets[key]
       shifts
     end
-  end
-
-  def make_random_keys
-    rand(0...100_000).to_s.rjust(5, "0")
   end
 
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -1,6 +1,7 @@
 require "./test/test_helper"
 require "mocha/minitest"
 require "./lib/enigma"
+require "date"
 
 class EnigmaTest < MiniTest::Test
 
@@ -28,6 +29,17 @@ class EnigmaTest < MiniTest::Test
 		expected = { encryption: "keder ohulw", key: "02715", date: "040895" }
 		assert_equal expected, enigma.encrypt("hello world", "02715")
 	end
+
+
+	def test_it_can_decrypt_a_message_given_a_key # without date
+		enigma_1 = Enigma.new
+		enigma_1.stubs(:get_date_of_today).returns("040895")
+		encrypted = enigma_1.encrypt("hello world", "02715")
+
+		expected = { decryption: "hello world", key: "02715", date: "040895" }
+		assert_equal expected, enigma_1.decrypt(encrypted[:encryption], "02715")
+	end
+
 
 	def test_it_has_a_real_date
 		enigma = Enigma.new

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -157,4 +157,13 @@ class EnigmaTest < MiniTest::Test
 		assert_equal expected, enigma_2.encrypt("hello world")
 	end
 
+	def test_it_can_make_random_keys
+		enigma = Enigma.new
+    random_keys = enigma.make_random_keys
+    assert_instance_of String, random_keys
+    assert_equal 5, random_keys.length
+    assert_includes 0...100_000, random_keys.to_i
+  end
+
+
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -163,7 +163,7 @@ class EnigmaTest < MiniTest::Test
     assert_instance_of String, random_keys
     assert_equal 5, random_keys.length
     assert_includes 0...100_000, random_keys.to_i
-		assert_equal true, random_keys.each_char.all? { |key| ("0".."9").include? key }
-  end
+		assert_equal true, random_keys.each_char.all? { |key| ("0".."9").include?(key) }
+	end
 
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -144,14 +144,14 @@ class EnigmaTest < MiniTest::Test
 	def test_it_can_encrypt_a_message_with_no_additional_input
 		enigma_1 = Enigma.new
 		enigma_1.stubs(:get_date_of_today).returns("040895")
-		enigma_1.stubs(:get_random_key).returns("02715")
+		enigma_1.stubs(:make_random_keys).returns("02715")
 
 		expected = {:encryption=>"keder ohulw", :key=>"02715", :date=>"040895"}
 		assert_equal expected, enigma_1.encrypt("hello world")
 
 		enigma_2 = Enigma.new
 		enigma_2.stubs(:get_date_of_today).returns("070620")
-		enigma_2.stubs(:get_random_key).returns("02715")
+		enigma_2.stubs(:make_random_keys).returns("02715")
 
 		expected = {:encryption=>"nib udmcxpu", :key=>"02715", :date=>"070620"}
 		assert_equal expected, enigma_2.encrypt("hello world")
@@ -163,7 +163,7 @@ class EnigmaTest < MiniTest::Test
     assert_instance_of String, random_keys
     assert_equal 5, random_keys.length
     assert_includes 0...100_000, random_keys.to_i
+		assert_equal true, random_keys.each_char.all? { |key| ("0".."9").include? key }
   end
-
 
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -141,4 +141,20 @@ class EnigmaTest < MiniTest::Test
 		assert_equal false, enigma.is_valid_input?(valid_message_6, valid_key_6, invalid_date_6)
 	end
 
+	def test_it_can_encrypt_a_message_with_no_additional_input
+		enigma_1 = Enigma.new
+		enigma_1.stubs(:get_date_of_today).returns("040895")
+		enigma_1.stubs(:get_random_key).returns("02715")
+
+		expected = {:encryption=>"keder ohulw", :key=>"02715", :date=>"040895"}
+		assert_equal expected, enigma_1.encrypt("hello world")
+
+		enigma_2 = Enigma.new
+		enigma_2.stubs(:get_date_of_today).returns("070620")
+		enigma_2.stubs(:get_random_key).returns("02715")
+
+		expected = {:encryption=>"nib udmcxpu", :key=>"02715", :date=>"070620"}
+		assert_equal expected, enigma_2.encrypt("hello world")
+	end
+
 end

--- a/test/gear_test.rb
+++ b/test/gear_test.rb
@@ -34,13 +34,6 @@ class GearTest < MiniTest::Test
     assert_equal expected_shifts, @gear.make_shifts
   end
 
-  def test_it_can_make_random_keys
-    random_keys = @gear.make_random_keys
-    assert_instance_of String, random_keys
-    assert_equal 5, random_keys.length
-    assert_includes 0...100_000, random_keys.to_i
-  end
-
   def test_its_class_can_output_shifts_key_and_date
     expected_shifts = { A:3, B:27, C:73, D:20 }
     assert_equal expected_shifts, Gear.get_shifts("02715", "040895")


### PR DESCRIPTION
```ruby
enigma.encrypt("hello world")
#=> {:encryption=>"xtpqdo tg h", :key=>"66586", :date=>"070620"}

enigma.encrypt("hello world")
#=> {:encryption=>"e hwlvszog ", :key=>"47238", :date=>"070620"}

enigma.encrypt("hello world")
#=> {:encryption=>"aoyjhjimkvq", :key=>"70679", :date=>"070620"}

enigma.encrypt("hello world")
#=> {:encryption=>"cetoj drmll", :key=>"72357", :date=>"070620"}

enigma.encrypt("hello world")
#=> {:encryption=>"e lhlvwkogd", :key=>"47277", :date=>"070620"}
```